### PR TITLE
Update admin and fee receiver accounts

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -30,7 +30,7 @@ startup_wait = 10000
 url = "https://api.mainnet-beta.solana.com"
 
 [[test.validator.clone]]
-address = "DNXgeM9EiiaAbaWvwjHj9fQQLAX5ZsfHyvmYUNRAdNC8" # pool fee receiver
+address = "42dvDR9xMUZ2eBm451H8ogonQh22btpxcfqtt1uDi6qC" # pool fee receiver
 
 [[test.validator.clone]]
 address = "D4FPEruKEHrG5TenZ2mpDGEfu1iUvTiqBxvpU8HLBvC2" # index 0 AMM Config account

--- a/client_config.ini
+++ b/client_config.ini
@@ -2,6 +2,6 @@
 http_url = https://api.devnet.solana.com
 ws_url = wss://api.devnet.solana.com/
 payer_path = id.json
-admin_path = adMCyoCgfkg7bQiJ9aBJ59H3BXLY3r5LNLfPpQfMzBe.json
+admin_path = 89VB5UmvopuCFmp5Mf8YPX28fGvvqn79afCgouQuPyhY.json
 raydium_cp_program = CPMDWBwJDtYax9qW7AyRuVC19Cc4L4Vcy4n2BHAbHkCW
 slippage = 0.01

--- a/programs/cp-swap/src/lib.rs
+++ b/programs/cp-swap/src/lib.rs
@@ -27,17 +27,17 @@ declare_id!("CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C");
 pub mod admin {
     use super::{pubkey, Pubkey};
     #[cfg(feature = "devnet")]
-    pub const ID: Pubkey = pubkey!("adMCyoCgfkg7bQiJ9aBJ59H3BXLY3r5LNLfPpQfMzBe");
+    pub const ID: Pubkey = pubkey!("89VB5UmvopuCFmp5Mf8YPX28fGvvqn79afCgouQuPyhY");
     #[cfg(not(feature = "devnet"))]
-    pub const ID: Pubkey = pubkey!("GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ");
+    pub const ID: Pubkey = pubkey!("89VB5UmvopuCFmp5Mf8YPX28fGvvqn79afCgouQuPyhY");
 }
 
 pub mod create_pool_fee_reveiver {
     use super::{pubkey, Pubkey};
     #[cfg(feature = "devnet")]
-    pub const ID: Pubkey = pubkey!("G11FKBRaAkHAKuLCgLM6K6NUc9rTjPAznRCjZifrTQe2");
+    pub const ID: Pubkey = pubkey!("42dvDR9xMUZ2eBm451H8ogonQh22btpxcfqtt1uDi6qC");
     #[cfg(not(feature = "devnet"))]
-    pub const ID: Pubkey = pubkey!("DNXgeM9EiiaAbaWvwjHj9fQQLAX5ZsfHyvmYUNRAdNC8");
+    pub const ID: Pubkey = pubkey!("42dvDR9xMUZ2eBm451H8ogonQh22btpxcfqtt1uDi6qC");
 }
 
 pub const AUTH_SEED: &str = "vault_and_lp_mint_auth_seed";

--- a/tests/utils/instruction.ts
+++ b/tests/utils/instruction.ts
@@ -267,7 +267,7 @@ export async function initialize(
     initAmount0: new BN(10000000000),
     initAmount1: new BN(20000000000),
   },
-  createPoolFee = new PublicKey("DNXgeM9EiiaAbaWvwjHj9fQQLAX5ZsfHyvmYUNRAdNC8")
+  createPoolFee = new PublicKey("42dvDR9xMUZ2eBm451H8ogonQh22btpxcfqtt1uDi6qC")
 ) {
   const [auth] = await getAuthAddress(program.programId);
   const [poolAddress] = await getPoolAddress(


### PR DESCRIPTION
## Summary
- update admin constant to new public key
- update fee receiver constant for pool creation
- set new admin key path in client config
- adjust Anchor test clone address
- update TypeScript helper defaults

## Testing
- `cargo check` *(fails: could not download crates)*
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn install` *(fails: tunneling socket could not be established)*