### PR TITLE
Implement flat fee model

### DIFF
--- a/programs/cp-swap/src/curve/fees.rs
+++ b/programs/cp-swap/src/curve/fees.rs
@@ -1,6 +1,7 @@
 //! All fee information, to be used for validation currently
 
 pub const FEE_RATE_DENOMINATOR_VALUE: u64 = 1_000_000;
+pub const DEFAULT_FLAT_FEE: u64 = 100_000;
 
 pub struct Fees {}
 
@@ -24,12 +25,8 @@ pub fn floor_div(token_amount: u128, fee_numerator: u128, fee_denominator: u128)
 
 impl Fees {
     /// Calculate the trading fee in trading tokens
-    pub fn trading_fee(amount: u128, trade_fee_rate: u64) -> Option<u128> {
-        ceil_div(
-            amount,
-            u128::from(trade_fee_rate),
-            u128::from(FEE_RATE_DENOMINATOR_VALUE),
-        )
+    pub fn trading_fee(_amount: u128, trade_fee_rate: u64) -> Option<u128> {
+        Some(u128::from(trade_fee_rate))
     }
 
     /// Calculate the owner protocol fee in trading tokens
@@ -51,17 +48,6 @@ impl Fees {
     }
 
     pub fn calculate_pre_fee_amount(post_fee_amount: u128, trade_fee_rate: u64) -> Option<u128> {
-        if trade_fee_rate == 0 {
-            Some(post_fee_amount)
-        } else {
-            let numerator = post_fee_amount.checked_mul(u128::from(FEE_RATE_DENOMINATOR_VALUE))?;
-            let denominator =
-                u128::from(FEE_RATE_DENOMINATOR_VALUE).checked_sub(u128::from(trade_fee_rate))?;
-
-            numerator
-                .checked_add(denominator)?
-                .checked_sub(1)?
-                .checked_div(denominator)
-        }
+        post_fee_amount.checked_add(u128::from(trade_fee_rate))
     }
 }

--- a/programs/cp-swap/src/instructions/admin/create_config.rs
+++ b/programs/cp-swap/src/instructions/admin/create_config.rs
@@ -1,5 +1,6 @@
 use crate::error::ErrorCode;
 use crate::states::*;
+use crate::curve::fees::DEFAULT_FLAT_FEE;
 use anchor_lang::prelude::*;
 use std::ops::DerefMut;
 
@@ -42,7 +43,11 @@ pub fn create_amm_config(
     amm_config.bump = ctx.bumps.amm_config;
     amm_config.disable_create_pool = false;
     amm_config.index = index;
-    amm_config.trade_fee_rate = trade_fee_rate;
+    amm_config.trade_fee_rate = if trade_fee_rate == 0 {
+        DEFAULT_FLAT_FEE
+    } else {
+        trade_fee_rate
+    };
     amm_config.protocol_fee_rate = protocol_fee_rate;
     amm_config.fund_fee_rate = fund_fee_rate;
     amm_config.create_pool_fee = create_pool_fee;

--- a/programs/cp-swap/src/instructions/admin/update_config.rs
+++ b/programs/cp-swap/src/instructions/admin/update_config.rs
@@ -44,7 +44,7 @@ fn update_protocol_fee_rate(amm_config: &mut Account<AmmConfig>, protocol_fee_ra
 }
 
 fn update_trade_fee_rate(amm_config: &mut Account<AmmConfig>, trade_fee_rate: u64) {
-    assert!(trade_fee_rate < FEE_RATE_DENOMINATOR_VALUE);
+    assert!(trade_fee_rate > 0);
     amm_config.trade_fee_rate = trade_fee_rate;
 }
 

--- a/programs/cp-swap/src/lib.rs
+++ b/programs/cp-swap/src/lib.rs
@@ -51,7 +51,7 @@ pub mod raydium_cp_swap {
     ///
     /// * `ctx`- The accounts needed by instruction.
     /// * `index` - The index of amm config, there may be multiple config.
-    /// * `trade_fee_rate` - Trade fee rate, can be changed.
+    /// * `trade_fee_rate` - Flat trade fee amount.
     /// * `protocol_fee_rate` - The rate of protocol fee within trade fee.
     /// * `fund_fee_rate` - The rate of fund fee within trade fee.
     ///
@@ -63,7 +63,7 @@ pub mod raydium_cp_swap {
         fund_fee_rate: u64,
         create_pool_fee: u64,
     ) -> Result<()> {
-        assert!(trade_fee_rate < FEE_RATE_DENOMINATOR_VALUE);
+        assert!(trade_fee_rate > 0);
         assert!(protocol_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
         assert!(fund_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);
         assert!(fund_fee_rate + protocol_fee_rate <= FEE_RATE_DENOMINATOR_VALUE);

--- a/programs/cp-swap/src/states/config.rs
+++ b/programs/cp-swap/src/states/config.rs
@@ -12,7 +12,7 @@ pub struct AmmConfig {
     pub disable_create_pool: bool,
     /// Config index
     pub index: u16,
-    /// The trade fee, denominated in hundredths of a bip (10^-6)
+    /// The flat trade fee amount
     pub trade_fee_rate: u64,
     /// The protocol fee
     pub protocol_fee_rate: u64,

--- a/tests/deposit.test.ts
+++ b/tests/deposit.test.ts
@@ -29,7 +29,7 @@ describe("deposit test", () => {
       owner,
       {
         config_index: 0,
-        tradeFeeRate: new BN(10),
+        tradeFeeRate: new BN(100000),
         protocolFeeRate: new BN(1000),
         fundFeeRate: new BN(25000),
         create_fee: new BN(0),
@@ -110,7 +110,7 @@ describe("deposit test", () => {
         owner,
         {
           config_index: 0,
-          tradeFeeRate: new BN(10),
+          tradeFeeRate: new BN(100000),
           protocolFeeRate: new BN(1000),
           fundFeeRate: new BN(25000),
           create_fee: new BN(0),
@@ -251,7 +251,7 @@ describe("deposit test", () => {
       owner,
       {
         config_index: 0,
-        tradeFeeRate: new BN(10),
+        tradeFeeRate: new BN(100000),
         protocolFeeRate: new BN(1000),
         fundFeeRate: new BN(25000),
         create_fee: new BN(0),

--- a/tests/initialize.test.ts
+++ b/tests/initialize.test.ts
@@ -25,7 +25,7 @@ describe("initialize test", () => {
         owner,
         {
           config_index: 0,
-          tradeFeeRate: new BN(10),
+          tradeFeeRate: new BN(100000),
           protocolFeeRate: new BN(1000),
           fundFeeRate: new BN(25000),
           create_fee: new BN(0),
@@ -72,7 +72,7 @@ describe("initialize test", () => {
         owner,
         {
           config_index: 0,
-          tradeFeeRate: new BN(10),
+          tradeFeeRate: new BN(100000),
           protocolFeeRate: new BN(1000),
           fundFeeRate: new BN(25000),
           create_fee: new BN(100000000),
@@ -120,7 +120,7 @@ describe("initialize test", () => {
         owner,
         {
           config_index: 0,
-          tradeFeeRate: new BN(10),
+          tradeFeeRate: new BN(100000),
           protocolFeeRate: new BN(1000),
           fundFeeRate: new BN(25000),
           create_fee: new BN(100000000),

--- a/tests/swap.test.ts
+++ b/tests/swap.test.ts
@@ -22,7 +22,7 @@ describe("swap test", () => {
       owner,
       {
         config_index: 0,
-        tradeFeeRate: new BN(10),
+        tradeFeeRate: new BN(100000),
         protocolFeeRate: new BN(1000),
         fundFeeRate: new BN(25000),
         create_fee: new BN(0),
@@ -75,7 +75,7 @@ describe("swap test", () => {
       owner,
       {
         config_index: 0,
-        tradeFeeRate: new BN(10),
+        tradeFeeRate: new BN(100000),
         protocolFeeRate: new BN(1000),
         fundFeeRate: new BN(25000),
         create_fee: new BN(0),
@@ -138,7 +138,7 @@ describe("swap test", () => {
       owner,
       {
         config_index: 0,
-        tradeFeeRate: new BN(10),
+        tradeFeeRate: new BN(100000),
         protocolFeeRate: new BN(1000),
         fundFeeRate: new BN(25000),
         create_fee: new BN(0),

--- a/tests/withdraw.test.ts
+++ b/tests/withdraw.test.ts
@@ -26,7 +26,7 @@ describe("withdraw test", () => {
       owner,
       {
         config_index: 0,
-        tradeFeeRate: new BN(10),
+        tradeFeeRate: new BN(100000),
         protocolFeeRate: new BN(1000),
         fundFeeRate: new BN(25000),
         create_fee: new BN(0),
@@ -71,7 +71,7 @@ describe("withdraw test", () => {
       owner,
       {
         config_index: 0,
-        tradeFeeRate: new BN(10),
+        tradeFeeRate: new BN(100000),
         protocolFeeRate: new BN(1000),
         fundFeeRate: new BN(25000),
         create_fee: new BN(0),


### PR DESCRIPTION
## Summary
- switch to a fixed trade fee instead of a percentage
- set the default fee to 100000 base units
- update validations and tests for the new fee structure

## Testing
- `cargo test --quiet` *(fails: could not download crates)*
- `yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.test.ts` *(fails: dependencies missing)*