### PR TITLE
Redirect fund fees to pool creator

### DIFF
--- a/programs/cp-swap/src/instructions/admin/collect_fund_fee.rs
+++ b/programs/cp-swap/src/instructions/admin/collect_fund_fee.rs
@@ -8,8 +8,8 @@ use anchor_spl::token_interface::Token2022;
 use anchor_spl::token_interface::TokenAccount;
 #[derive(Accounts)]
 pub struct CollectFundFee<'info> {
-    /// Only admin or fund_owner can collect fee now
-    #[account(constraint = (owner.key() == amm_config.fund_owner || owner.key() == crate::admin::ID) @ ErrorCode::InvalidOwner)]
+    /// Only admin or pool creator can collect fee now
+    #[account(constraint = (owner.key() == pool_state.load()?.pool_creator || owner.key() == crate::admin::ID) @ ErrorCode::InvalidOwner)]
     pub owner: Signer<'info>,
 
     /// CHECK: pool vault and lp mint authority
@@ -25,7 +25,7 @@ pub struct CollectFundFee<'info> {
     #[account(mut)]
     pub pool_state: AccountLoader<'info, PoolState>,
 
-    /// Amm config account stores fund_owner
+    /// Amm config account
     #[account(address = pool_state.load()?.amm_config)]
     pub amm_config: Account<'info, AmmConfig>,
 

--- a/programs/cp-swap/src/instructions/admin/create_config.rs
+++ b/programs/cp-swap/src/instructions/admin/create_config.rs
@@ -46,6 +46,8 @@ pub fn create_amm_config(
     amm_config.protocol_fee_rate = protocol_fee_rate;
     amm_config.fund_fee_rate = fund_fee_rate;
     amm_config.create_pool_fee = create_pool_fee;
+    // Store fund owner for backwards compatibility; funds
+    // are now collected by the pool creator.
     amm_config.fund_owner = ctx.accounts.owner.key();
     Ok(())
 }

--- a/programs/cp-swap/src/instructions/admin/update_config.rs
+++ b/programs/cp-swap/src/instructions/admin/update_config.rs
@@ -74,6 +74,7 @@ fn set_new_fund_owner(amm_config: &mut Account<AmmConfig>, new_fund_owner: Pubke
         amm_config.fund_owner.to_string(),
         new_fund_owner.key().to_string()
     );
+    // Stored for compatibility; not used for fee collection
     amm_config.fund_owner = new_fund_owner;
     Ok(())
 }

--- a/programs/cp-swap/src/lib.rs
+++ b/programs/cp-swap/src/lib.rs
@@ -121,7 +121,8 @@ pub mod raydium_cp_swap {
         instructions::collect_protocol_fee(ctx, amount_0_requested, amount_1_requested)
     }
 
-    /// Collect the fund fee accrued to the pool
+    /// Collect the fund fee accrued to the pool. The pool creator is
+    /// entitled to these funds.
     ///
     /// # Arguments
     ///

--- a/programs/cp-swap/src/states/config.rs
+++ b/programs/cp-swap/src/states/config.rs
@@ -22,7 +22,8 @@ pub struct AmmConfig {
     pub create_pool_fee: u64,
     /// Address of the protocol fee owner
     pub protocol_owner: Pubkey,
-    /// Address of the fund fee owner
+    /// Address of the fund fee owner. Currently unused as fund fees
+    /// are directed to the pool creator.
     pub fund_owner: Pubkey,
     /// padding
     pub padding: [u64; 16],


### PR DESCRIPTION
## Summary
- ensure only the pool creator or admin can collect fund fees
- store fund owner only for compatibility
- document that pool creator receives fund fees

## Testing
- `cargo test --manifest-path programs/cp-swap/Cargo.toml --locked --offline` *(fails: no matching package named `anchor-spl` found)*