### PR TITLE
Redirect fund fees to pool creator

### DIFF
--- a/programs/cp-swap/src/instructions/admin/collect_fund_fee.rs
+++ b/programs/cp-swap/src/instructions/admin/collect_fund_fee.rs
@@ -8,8 +8,8 @@ use anchor_spl::token_interface::Token2022;
 use anchor_spl::token_interface::TokenAccount;
 #[derive(Accounts)]
 pub struct CollectFundFee<'info> {
-    /// Only admin or fund_owner can collect fee now
-    #[account(constraint = (owner.key() == amm_config.fund_owner || owner.key() == crate::admin::ID) @ ErrorCode::InvalidOwner)]
+    /// Only admin or pool creator can collect fee now
+    #[account(constraint = (owner.key() == pool_state.load()?.pool_creator || owner.key() == crate::admin::ID) @ ErrorCode::InvalidOwner)]
     pub owner: Signer<'info>,
 
     /// CHECK: pool vault and lp mint authority
@@ -25,7 +25,7 @@ pub struct CollectFundFee<'info> {
     #[account(mut)]
     pub pool_state: AccountLoader<'info, PoolState>,
 
-    /// Amm config account stores fund_owner
+    /// Amm config account
     #[account(address = pool_state.load()?.amm_config)]
     pub amm_config: Account<'info, AmmConfig>,
 

--- a/programs/cp-swap/src/instructions/admin/create_config.rs
+++ b/programs/cp-swap/src/instructions/admin/create_config.rs
@@ -45,7 +45,11 @@ pub fn create_amm_config(
     amm_config.trade_fee_rate = trade_fee_rate;
     amm_config.protocol_fee_rate = protocol_fee_rate;
     amm_config.fund_fee_rate = fund_fee_rate;
-    amm_config.create_pool_fee = create_pool_fee;
+    // creator fee is now disabled, keep interface but set to zero
+    let _ = create_pool_fee; // ignore user provided value
+    amm_config.create_pool_fee = 0;
+    // Store fund owner for backwards compatibility; funds
+    // are now collected by the pool creator.
     amm_config.fund_owner = ctx.accounts.owner.key();
     Ok(())
 }

--- a/programs/cp-swap/src/instructions/admin/update_config.rs
+++ b/programs/cp-swap/src/instructions/admin/update_config.rs
@@ -29,7 +29,11 @@ pub fn update_amm_config(ctx: Context<UpdateAmmConfig>, param: u8, value: u64) -
             let new_fund_owner = *ctx.remaining_accounts.iter().next().unwrap().key;
             set_new_fund_owner(amm_config, new_fund_owner)?;
         }
-        Some(5) => amm_config.create_pool_fee = value,
+        Some(5) => {
+            // creator fee is disabled; ignore provided value
+            let _ = value;
+            amm_config.create_pool_fee = 0;
+        }
         Some(6) => amm_config.disable_create_pool = if value == 0 { false } else { true },
         _ => return err!(ErrorCode::InvalidInput),
     }
@@ -74,6 +78,7 @@ fn set_new_fund_owner(amm_config: &mut Account<AmmConfig>, new_fund_owner: Pubke
         amm_config.fund_owner.to_string(),
         new_fund_owner.key().to_string()
     );
+    // Stored for compatibility; not used for fee collection
     amm_config.fund_owner = new_fund_owner;
     Ok(())
 }

--- a/programs/cp-swap/src/lib.rs
+++ b/programs/cp-swap/src/lib.rs
@@ -61,6 +61,8 @@ pub mod raydium_cp_swap {
         trade_fee_rate: u64,
         protocol_fee_rate: u64,
         fund_fee_rate: u64,
+        /// create_pool_fee parameter is ignored. Pool creation does not
+        /// charge a fee, but the argument is kept for backward compatibility.
         create_pool_fee: u64,
     ) -> Result<()> {
         assert!(trade_fee_rate < FEE_RATE_DENOMINATOR_VALUE);
@@ -121,7 +123,8 @@ pub mod raydium_cp_swap {
         instructions::collect_protocol_fee(ctx, amount_0_requested, amount_1_requested)
     }
 
-    /// Collect the fund fee accrued to the pool
+    /// Collect the fund fee accrued to the pool. The pool creator is
+    /// entitled to these funds.
     ///
     /// # Arguments
     ///

--- a/programs/cp-swap/src/states/config.rs
+++ b/programs/cp-swap/src/states/config.rs
@@ -18,11 +18,13 @@ pub struct AmmConfig {
     pub protocol_fee_rate: u64,
     /// The fund fee, denominated in hundredths of a bip (10^-6)
     pub fund_fee_rate: u64,
-    /// Fee for create a new pool
+    /// Fee for creating a new pool. Currently unused as pool
+    /// creation no longer charges a fee.
     pub create_pool_fee: u64,
     /// Address of the protocol fee owner
     pub protocol_owner: Pubkey,
-    /// Address of the fund fee owner
+    /// Address of the fund fee owner. Currently unused as fund fees
+    /// are directed to the pool creator.
     pub fund_owner: Pubkey,
     /// padding
     pub padding: [u64; 16],


### PR DESCRIPTION
## Summary
- ensure only the pool creator or admin can collect fund fees
- store fund owner only for compatibility
- disable create_pool_fee and document that it's unused

## Testing
- `cargo test --manifest-path programs/cp-swap/Cargo.toml --locked --offline` *(fails: no matching package named `anchor-spl` found)*